### PR TITLE
add client-id to kafka metrics when processing requests

### DIFF
--- a/source/extensions/filters/network/kafka/BUILD
+++ b/source/extensions/filters/network/kafka/BUILD
@@ -259,5 +259,7 @@ envoy_cc_library(
     external_deps = ["abseil_optional"],
     deps = [
         "//source/common/common:macros",
+        "//source/common/runtime:runtime_lib",
+        "//source/common/stats:symbol_table_lib",
     ],
 )

--- a/source/extensions/filters/network/kafka/broker/filter.cc
+++ b/source/extensions/filters/network/kafka/broker/filter.cc
@@ -1,4 +1,5 @@
 #include "extensions/filters/network/kafka/broker/filter.h"
+#include "extensions/filters/network/kafka/kafka_types.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -32,7 +33,7 @@ KafkaMetricsFacadeImpl::KafkaMetricsFacadeImpl(TimeSource& time_source,
 // When request is successfully parsed, increase type count and store its arrival timestamp.
 void KafkaMetricsFacadeImpl::onMessage(AbstractRequestSharedPtr request) {
   const RequestHeader& header = request->request_header_;
-  request_metrics_->onRequest(header.api_key_);
+  request_metrics_->onRequest(header.api_key_, header.client_id_);
 
   const MonotonicTime request_arrival_ts = time_source_.monotonicTime();
   request_arrivals_[header.correlation_id_] = request_arrival_ts;

--- a/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
+++ b/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
@@ -85,7 +85,7 @@ public:
     // instead of regex we could also simply check the prefix of a client id
     // but the regex is far more flexible.
     // This regex matches metrics *not* starting with "metadata-proxy." or "metadata-proxy"
-    regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy(\\.|$)))");
+    regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy))");
   };
 
   void onRequest(const int16_t api_key, const NullableString& client_id) override {

--- a/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
+++ b/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
@@ -15,8 +15,14 @@
 #include <array>
 #include <functional>
 
+#include "common/common/regex.h"
+#include "common/runtime/runtime_impl.h"
+#include "common/stats/symbol_table_impl.h"
+
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
+
+#include "extensions/filters/network/kafka/kafka_types.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -48,7 +54,7 @@ public:
   /**
    * Invoked when properly-parsed message is received.
    */
-  virtual void onRequest(const int16_t api_key) PURE;
+  virtual void onRequest(const int16_t api_key, const NullableString& client_id) PURE;
 
   /**
    * Invoked when an unknown message is received.
@@ -70,14 +76,47 @@ class RichRequestMetricsImpl: public RichRequestMetrics {
 public:
   RichRequestMetricsImpl(Stats::Scope& scope, std::string stat_prefix): metrics_({
     KAFKA_REQUEST_METRICS(POOL_COUNTER_PREFIX(scope, fmt::format("kafka.{}.request.",
-      stat_prefix)))}) {};
+      stat_prefix)))}),
+      scope_(scope),
+      stat_name_set_(scope.symbolTable().makeSet("Kafka")),
+      stat_prefix_(stat_prefix) {
+    // TODO(amre): make two following parameters configurable
+    all_tagged_metrics_sample_rate_ = 100;
+    // instead of regex we could also simply check the prefix of a client id
+    // but the regex is far more flexible.
+    // This regex matches metrics *not* starting with "metadata-proxy."
+    regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy\\.)).+?$");
+  };
 
-  void onRequest(const int16_t api_key) override {
+  void onRequest(const int16_t api_key, const NullableString& client_id) override {
     // Both successful message parsing & metrics list depend on protocol-generated code, what means
     // both do support the same api keys.
+    std::string non_null_client_id = client_id ? *client_id : "unknown";
     switch (api_key) {
     {% for message_type in message_types %}
     case {{ message_type.get_extra('api_key') }} :
+      // based on the configured rate (probabilistically)
+      if (random_.random() % 100 <= all_tagged_metrics_sample_rate_) {
+        scope_.counterFromStatName(stat_name_set_->add(
+            absl::StrCat(
+              fmt::format("kafka.{}.request.", stat_prefix_),
+              "request_type.{{ message_type.name_in_c_case() }}.",
+              fmt::format("client_id.{}", non_null_client_id)
+            )
+          )
+        ).inc();
+      }
+      // special metric for client ids that matches the regex (e.g., not from metadata proxy)
+      if (regex_ && regex_ -> match(non_null_client_id)) {
+        scope_.counterFromStatName(stat_name_set_->add(
+            absl::StrCat(
+              fmt::format("kafka.{}.request.alert.", stat_prefix_),
+              "request_type.{{ message_type.name_in_c_case() }}.",
+              fmt::format("client_id.{}", non_null_client_id)
+            )
+          )
+        ).inc();
+      }
       metrics_.{{ message_type.name_in_c_case() }}_.inc();
       return;
     {% endfor %}
@@ -90,6 +129,12 @@ public:
 
 private:
   KafkaRequestMetrics metrics_;
+  Stats::Scope& scope_;
+  Stats::StatNameSetPtr stat_name_set_;
+  std::string stat_prefix_;
+  Runtime::RandomGeneratorImpl random_;
+  unsigned long all_tagged_metrics_sample_rate_;
+  Regex::CompiledMatcherPtr regex_;
 };
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
+++ b/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
@@ -37,7 +37,8 @@ namespace Kafka {
   COUNTER({{ message_type.name_in_c_case() }})                                                     \
 {% endfor %}                                                                                       \
   COUNTER(unknown)                                                                                 \
-  COUNTER(failure)
+  COUNTER(failure)                                                                                 \
+  COUNTER(alert)
 
 struct KafkaRequestMetrics {
   KAFKA_REQUEST_METRICS(GENERATE_COUNTER_STRUCT)
@@ -79,13 +80,17 @@ public:
       stat_prefix)))}),
       scope_(scope),
       stat_name_set_(scope.symbolTable().makeSet("Kafka")),
-      stat_prefix_(stat_prefix) {
+      stat_prefix_(stat_prefix),
+      api_calls_((1 << 3) | (1 << 6) | (1 << 10) | (1 << 18)) {
     // TODO(amre): make two following parameters configurable
-    all_tagged_metrics_sample_rate_ = 5;
+    all_tagged_metrics_sample_rate_ = 0;
     // instead of regex we could also simply check the prefix of a client id
     // but the regex is far more flexible.
     // This regex matches metrics *not* starting with "metadata-proxy." or "metadata-proxy"
     regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy))");
+
+    // a bitmask to check for calls to create metrics for
+    // 3 - metadata; 6 - update-metadata; 10 - find-coordinator; 18 - api-versions
   };
 
   void onRequest(const int16_t api_key, const NullableString& client_id) override {
@@ -96,7 +101,7 @@ public:
     {% for message_type in message_types %}
     case {{ message_type.get_extra('api_key') }} :
       // based on the configured rate (probabilistically)
-      if (random_.random() % 100 <= all_tagged_metrics_sample_rate_) {
+      if (all_tagged_metrics_sample_rate_ > 0 && random_.random() % 100 <= all_tagged_metrics_sample_rate_) {
         scope_.counterFromStatName(stat_name_set_->add(
             absl::StrCat(
               fmt::format("kafka.{}.request.", stat_prefix_),
@@ -107,7 +112,8 @@ public:
         ).inc();
       }
       // special metric for client ids that matches the regex (e.g., not from metadata proxy)
-      if (regex_ && regex_ -> match(non_null_client_id)) {
+      // and are one of the API calls we are interested in
+      if (((1 << api_key) & api_calls_) && regex_ && regex_ -> match(non_null_client_id)) {
         scope_.counterFromStatName(stat_name_set_->add(
             absl::StrCat(
               fmt::format("kafka.{}.request.alert.", stat_prefix_),
@@ -135,6 +141,7 @@ private:
   Runtime::RandomGeneratorImpl random_;
   unsigned long all_tagged_metrics_sample_rate_;
   Regex::CompiledMatcherPtr regex_;
+  const unsigned api_calls_;
 };
 
 } // namespace Kafka

--- a/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
+++ b/source/extensions/filters/network/kafka/protocol/request_metrics_h.j2
@@ -81,11 +81,11 @@ public:
       stat_name_set_(scope.symbolTable().makeSet("Kafka")),
       stat_prefix_(stat_prefix) {
     // TODO(amre): make two following parameters configurable
-    all_tagged_metrics_sample_rate_ = 100;
+    all_tagged_metrics_sample_rate_ = 5;
     // instead of regex we could also simply check the prefix of a client id
     // but the regex is far more flexible.
-    // This regex matches metrics *not* starting with "metadata-proxy."
-    regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy\\.)).+?$");
+    // This regex matches metrics *not* starting with "metadata-proxy." or "metadata-proxy"
+    regex_ = Regex::Utility::parseStdRegexAsCompiledMatcher("^(?!(metadata-proxy(\\.|$)))");
   };
 
   void onRequest(const int16_t api_key, const NullableString& client_id) override {


### PR DESCRIPTION
Description:
Emit new metrics for each kafka request with the following format:
kafka.<stat_prefix>.request{type=<message_type>,client_id=<client_id>}

[Screenshot](https://files.slack.com/files-pri/T02511RD4-FT1K3CZA4/screen_shot_2020-01-23_at_12.25.50_pm.png)

To take full advantage of this change, we need to specify `stats_tags` in envoy configuration for kafka: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/stats.proto#envoy-api-msg-config-metrics-v2-tagspecifier

Risk Level: low
Testing: tested using containers